### PR TITLE
Adding Contextual Information

### DIFF
--- a/SwiftUICatalog/Views/Sections/Additional Views/AlertsView.swift
+++ b/SwiftUICatalog/Views/Sections/Additional Views/AlertsView.swift
@@ -30,7 +30,16 @@ import SwiftUI
 
 struct AlertsComponentView: View {
     var body: some View {
-        Text("Alerts examples")
+        HeaderView( title: "Alerts examples")
+        
+        // Contextual information: a short intro to the elements we are showcasing
+        Group {
+            Text("title")
+                .fontWeight(.heavy)
+            Text("description of what we show case")
+                .fontWeight(.light)
+        }
+        .padding()
     }
 }
 

--- a/SwiftUICatalog/Views/Sections/Additional Views/PopoversView.swift
+++ b/SwiftUICatalog/Views/Sections/Additional Views/PopoversView.swift
@@ -30,7 +30,16 @@ import SwiftUI
 
 struct PopoversComponentView: View {
     var body: some View {
-        Text("Popovers examples")
+        HeaderView( title: "Popovers examples")
+        
+        // Contextual information: a short intro to the elements we are showcasing
+        Group {
+            Text("title")
+                .fontWeight(.heavy)
+            Text("description of what we show case")
+                .fontWeight(.light)
+        }
+        .padding()
     }
 }
 

--- a/SwiftUICatalog/Views/Sections/Additional Views/SpacersDividersView.swift
+++ b/SwiftUICatalog/Views/Sections/Additional Views/SpacersDividersView.swift
@@ -37,7 +37,16 @@ import SwiftUI
 
 struct SpacersDividersView: View {
     var body: some View {
-        Text("Spacers and dividers in SwiftUI")
+        HeaderView( title:"Spacers and dividers in SwiftUI")
+        
+        // Contextual information: a short intro to the elements we are showcasing
+        Group {
+            Text("title")
+                .fontWeight(.heavy)
+            Text("description of what we show case")
+                .fontWeight(.light)
+        }
+        .padding()
     }
 }
 

--- a/SwiftUICatalog/Views/Sections/Additional Views/TimelineViews.swift
+++ b/SwiftUICatalog/Views/Sections/Additional Views/TimelineViews.swift
@@ -36,7 +36,16 @@ import SwiftUI
 
 struct TimelineViews: View {
     var body: some View {
-        Text("Timeline views in SwiftUI")
+        HeaderView( title: "Timeline views in SwiftUI")
+        
+        // Contextual information: a short intro to the elements we are showcasing
+        Group {
+            Text("title")
+                .fontWeight(.heavy)
+            Text("description of what we show case")
+                .fontWeight(.light)
+        }
+        .padding()
     }
 }
 

--- a/SwiftUICatalog/Views/Sections/Controls/ButtonsView.swift
+++ b/SwiftUICatalog/Views/Sections/Controls/ButtonsView.swift
@@ -51,13 +51,13 @@ struct ButtonsComponentsView: View {
             
             // MARK: - basics of buttons
             Group {
-                HeaderView(title: "The basics of buttons")
                 
-                Divider()
+                Group {
+                    Text("Rounded Button")
+                        .fontWeight(.heavy)
+                    Text("One of the most usual designs for buttons is to include rounded corners. You can see how to achieve that here, using a custon view modifier")
+                        .fontWeight(.light)
 
-                HStack {
-                    Text("Rounded borders")
-                    Spacer()
                     Button(action: {},
                            label: {
                             Text("Click")
@@ -65,12 +65,15 @@ struct ButtonsComponentsView: View {
                                 .modifier(ButtonRoundedModifier(radius: 10,
                                                                 lineWidth: 5))
                            })
-                    
                 }
-                
-                HStack {
+                .padding()
+
+                Group {
                     Text("Specific Rounded borders with custom shape")
-                    Spacer()
+                        .fontWeight(.heavy)
+                    Text("Sometime we want to give the borders of a button a rounded style, but not to all of them. This can be achieved with a custom shape as an overlay for the standard Button View")
+                        .fontWeight(.light)
+
                     Button(action: {},
                            label: {
                             Text("Click")
@@ -83,12 +86,14 @@ struct ButtonsComponentsView: View {
                                         .stroke(Color.accentColor, lineWidth: 5)
                                 )
                            })
-                    
                 }
+                .padding()
 
-                HStack {
+                Group {
                     Text("Stroked borders")
-                    Spacer()
+                        .fontWeight(.heavy)
+                    Text("Borders can also be drawn with a certain stroke pattern by using an overlay and a specific StrokeStyle")
+                        .fontWeight(.light)
                     Button(action: {}) {
                         Text("Click")
                             .modifier(ButtonFontModifier())
@@ -99,11 +104,11 @@ struct ButtonsComponentsView: View {
                             )
                     }
                 }
-                
+                .padding()
             
-                HStack {
+                Group {
                     Text("Button with plan background")
-                    Spacer()
+                        .fontWeight(.heavy)
                     Button(action: {}, label: {
                         Text("Click")
                             .padding()
@@ -111,20 +116,22 @@ struct ButtonsComponentsView: View {
                     })
                     .background(Color.accentColor)
                 }
+                .padding()
 
-                HStack {
+                Group {
                     Text("Button with image")
-                    Spacer()
+                        .fontWeight(.heavy)
                     Button(action: {}, label: {
                         Image(systemName: "person")
                             .padding()
                     })
                     .border(Color.accentColor, width: 5)
                 }
-                
-                HStack {
+                .padding()
+
+                Group {
                     Text("Button with icon & label")
-                    Spacer()
+                        .fontWeight(.heavy)
                     Button(action: {}, label: {
                         Label {
                             Text("Add person")
@@ -136,49 +143,40 @@ struct ButtonsComponentsView: View {
                     })
                     .modifier(ButtonBorderModifier())
                 }
-                
-                HStack {
+                .padding()
+
+                Group {
                     Text("Button with label")
-                    Spacer()
+                        .fontWeight(.heavy)
                     Button(action: {}, label: {
                         Text("Add ")
                             .modifier(ButtonFontModifier())
                     })
                     .modifier(ButtonBorderModifier())
                 }
-            }
-            .padding(.top, 6)
-            .padding(.bottom, 12)
-            .padding(.leading, 16)
-            .padding(.trailing, 24)
-            
-            Divider()
-            
-            // MARK: - styling
-            Group {
-                HeaderView(title: "Styling buttons")
-                
-                HStack {
-                    Text("BorderlessButtonStyle:")
-                    Spacer()
+                .padding()
+
+                // MARK: - styling
+                Group {
+                    Text("BorderlessButtonStyle")
+                        .fontWeight(.heavy)
                     Button("Style me: borderless", action: {})
                         .buttonStyle(BorderlessButtonStyle())
-                }
-                .padding(.bottom, 12)
-
-                HStack {
-                    Text("PlainButtonStyle:")
-                    Spacer()
+                    
+                    
+                    Text("PlainButtonStyle")
+                        .fontWeight(.heavy)
                     Button("Style me: plain", action: {})
                         .buttonStyle(PlainButtonStyle())
                 }
-                .padding(.bottom, 12)
-            }
-            .padding(.leading, 16)
-            .padding(.trailing, 16)
+                .padding()
+                // end of group
 
-            
+            }
+            // end of main group
+      
         }
+        // end of scrollview list
         
     }
 }

--- a/SwiftUICatalog/Views/Sections/Controls/ButtonsView.swift
+++ b/SwiftUICatalog/Views/Sections/Controls/ButtonsView.swift
@@ -46,12 +46,15 @@ struct ButtonsComponentsView: View {
     
     
     var body: some View {
+        
         ScrollView {
             
+            HeaderView(title: "Buttons in SwiftUI")
             
             // MARK: - basics of buttons
             Group {
                 
+                // Contextual information: a short intro to the elements we are showcasing
                 Group {
                     Text("Rounded Button")
                         .fontWeight(.heavy)

--- a/SwiftUICatalog/Views/Sections/Controls/ColorPickersView.swift
+++ b/SwiftUICatalog/Views/Sections/Controls/ColorPickersView.swift
@@ -34,7 +34,15 @@ import SwiftUI
 ///
 struct ColorPickersView: View {
     var body: some View {
-        Text("Color Picker in SwiftUI")
+        HeaderView( title:"Color Picker in SwiftUI")
+        
+        // Contextual information: a short intro to the elements we are showcasing
+        Group {
+            Text("title")
+                .fontWeight(.heavy)
+            Text("description of what we show case")
+                .fontWeight(.light)
+        }
     }
 }
 

--- a/SwiftUICatalog/Views/Sections/Controls/DatePickersView.swift
+++ b/SwiftUICatalog/Views/Sections/Controls/DatePickersView.swift
@@ -55,10 +55,21 @@ struct DatePickersView: View {
 
     var body: some View {
         
-        List {
+        ScrollView {
+            
+            HeaderView(title: "DatePickers in SwiftUI")
+            
             // MARK: - date picker no range limit
             Group {
-                HeaderView(title: "No range limit")
+                
+                Group {
+                    Text( "No range limit")
+                        .fontWeight(.heavy)
+                    Text("By default date pickers do not have a limitation in the minimum or maximum day you can pick")
+                        .fontWeight(.light)
+                }
+                .padding()
+                
                 DatePicker(
                     "Start Date 1",
                     selection: $date1,
@@ -71,8 +82,16 @@ struct DatePickersView: View {
             }
             
             // MARK: - date picker with range limit
+            
             Group {
-                HeaderView(title: "Range limit")
+                Group {
+                    Text("Range limit")
+                        .fontWeight(.heavy)
+                    Text("Ranges can be configured using the in: parameter")
+                        .fontWeight(.light)
+                }
+                .padding()
+                
                 DatePicker(
                     "Start Date 2",
                      selection: $date2,
@@ -83,8 +102,16 @@ struct DatePickersView: View {
             }
             
             // MARK: - date pickers wheels
+            
             Group {
-                HeaderView(title: "Style wheels")
+                Group {
+                    Text( "Style wheels")
+                        .fontWeight(.heavy)
+                    Text("The date picker can adopt different style, here we show the WHEELS style")
+                        .fontWeight(.light)
+                }
+                .padding()
+                
                 DatePicker(
                     "Start Date 3",
                     selection: $date3,
@@ -93,9 +120,17 @@ struct DatePickersView: View {
                 .datePickerStyle(WheelDatePickerStyle())
                 .padding()
             }
+            
             // MARK: - date pickers compact
             Group {
-                HeaderView(title: "Style compact")
+                Group {
+                    Text("Style compact")
+                        .fontWeight(.heavy)
+                    Text("Compact styles make the date picker appear in one line, from which it is expanded")
+                        .fontWeight(.light)
+                }
+                .padding()
+                
                 DatePicker(
                     "Start Date 4",
                     selection: $date4,
@@ -104,9 +139,19 @@ struct DatePickersView: View {
                 .datePickerStyle(CompactDatePickerStyle())
                 .padding()
             }
+            
             // MARK: - date pickers graphical
+            
             Group {
-                HeaderView(title: "Style graphical")
+                
+                Group {
+                    Text("Style graphical")
+                        .fontWeight(.heavy)
+                    Text("The graphical style renders a calendar component inline. Watch out for the minimum recommended height.")
+                        .fontWeight(.light)
+                }
+                .padding()
+                
                 DatePicker(
                     "Start Date 4",
                     selection: $date4,

--- a/SwiftUICatalog/Views/Sections/Controls/ImagesView.swift
+++ b/SwiftUICatalog/Views/Sections/Controls/ImagesView.swift
@@ -40,34 +40,47 @@ struct ImagesComponentView: View {
             
             // MARK: - SF Symbols
             Group {
-                HeaderView(title: "Images with SF Symbols")
+                Text("Images with SF Symbols")
+                    .fontWeight(.heavy)
+                Text("With over 3,100 symbols, SF Symbols is a library designed by Apple. You can find more about SF Symbols in https://developer.apple.com/sf-symbols")
+                    .fontWeight(.light)
                 HStack(alignment: .center, spacing: 20) {
                     Image(systemName: "house.circle")
                     Image(systemName: "square.circle")
                     Image(systemName: "dpad")
                 }
             }
-            .padding(5)
+            .padding()
             
             Group {
-                HeaderView(title: "Images from bundle")
-                // Credits: https://pixabay.com/photos/dog-pet-corgi-animal-canine-6394502/
+                Text("Images from Bundle")
+                    .fontWeight(.heavy)
+                Text("Images can be uploaded from the app bundle, just the same as with UIKit, images can be scaled, resized, tiled, framed and also you can overlays on top of images to mask them to different shapes.")
+                    .fontWeight(.light)
+               // Credits: https://pixabay.com/photos/dog-pet-corgi-animal-canine-6394502/
                 Text("Corgie scaled to fit")
+                    .fontWeight(.semibold)
                 Image("corgie-love")
                     .resizable()
                     .scaledToFit()
                     .frame(width: 200, height: 200)
+
                 Text("Corgie scaled to fill")
+                        .fontWeight(.semibold)
                 Image("corgie-love")
                     .resizable()
                     .scaledToFill()
                     .frame(width: 200, height: 200)
+
                 Text("Corgie aspect ratio")
+                        .fontWeight(.semibold)
                 Image("corgie-love")
                     .resizable()
                     .aspectRatio(contentMode: .fit)
                     .frame(width: 200, height: 200)
+
                 Text("Corgie and circled overlay")
+                    .fontWeight(.semibold)
                 Image("corgie-love")
                     .resizable()
                     .scaledToFit()
@@ -79,12 +92,11 @@ struct ImagesComponentView: View {
                     .frame(width: 200, height: 200)
 
             }
-            .padding(5)
+            .padding()
             
             Group {
-                HeaderView(title: "Fitting images ")
-                
                 Text("Corgie fitting in a fixed frame")
+                    .fontWeight(.semibold)
                 Image("corgie-love")
                     .resizable()
                     .scaledToFit()
@@ -93,17 +105,16 @@ struct ImagesComponentView: View {
                     .clipped()
                 
                 Text("Tiled corgie")
+                    .fontWeight(.semibold)
                 Image("corgie-love")
                     .resizable(resizingMode: .tile)
                     .frame(width: 370, height: 900, alignment: .topLeading)
                     .border(Color.blue)
             }
-            .padding(5)
+            .padding()
 
         }
-        .padding(.top, 12)
-        .padding(.leading, 16)
-        .padding(.trailing, 16)
+      
     }
 }
 

--- a/SwiftUICatalog/Views/Sections/Controls/ImagesView.swift
+++ b/SwiftUICatalog/Views/Sections/Controls/ImagesView.swift
@@ -38,7 +38,11 @@ struct ImagesComponentView: View {
     var body: some View {
         ScrollView {
             
+            HeaderView(title: "Images in SwiftUI")
+
             // MARK: - SF Symbols
+            
+            // Contextual information: a short intro to the elements we are showcasing
             Group {
                 Text("Images with SF Symbols")
                     .fontWeight(.heavy)

--- a/SwiftUICatalog/Views/Sections/Controls/LabelsView.swift
+++ b/SwiftUICatalog/Views/Sections/Controls/LabelsView.swift
@@ -49,9 +49,21 @@ struct LabelsView: View {
     var body: some View {
         
         ScrollView {
+            
+            HeaderView(title: "Labels in SwiftUI")
+
             // MARK: - LABEL TYPE
             Group {
-                HeaderView(title: "Label Types")
+                
+                // Contextual information: a short intro to the elements we are showcasing
+                Group {
+                    Text("Label Types")
+                        .fontWeight(.heavy)
+                    Text("You can create a label in SwiftUI by adding an icon to it, using only a text or conbining text and icons in one label")
+                        .fontWeight(.light)
+                }
+                .padding()
+                
                 VStack {
                     Spacer()
                     HStack {
@@ -125,14 +137,21 @@ struct LabelsView: View {
             // MARK: - LABEL GROUPS
             Group {
                 VStack{
-                    HeaderView(title: "Label groups")
+                    Group {
+                        Text( "Label groups")
+                            .fontWeight(.heavy)
+                        Text("Labels can be grouped in other containers to layout them as a group")
+                            .fontWeight(.light)
+                    }
+                    .padding()
+                    
                     VStack {
                         Label("Rain", systemImage: "cloud.rain")
                         Label("Snow", systemImage: "snow")
                         Label("Sun", systemImage: "sun.max")
                     }
-                    
-                    HeaderView(title: "Label group (Label only)")
+                    .foregroundColor(.accentColor)
+                    .padding()
                     
                     /// To apply a common label style to a group of labels, apply the style
                     /// to the view hierarchy that contains the labels:
@@ -142,21 +161,30 @@ struct LabelsView: View {
                         Label("Sun", systemImage: "sun.max")
                     }
                     .labelStyle(titleOnly)
+                    .padding()
                     
-                    HeaderView(title: "Label group (Icon only)")
+                
                     VStack {
                         Label("", systemImage: "cloud.rain")
                         Label("", systemImage: "snow")
                         Label("", systemImage: "sun.max")
                     }
-                }.padding()
+                    .foregroundColor(.accentColor)
+}
             }
             Spacer()
             
             // MARK: - LABEL WITH CUSTOM VIEWS
             Group{
                 VStack {
-                    HeaderView(title: "Label With Custom Views")
+                    Group {
+                        Text( "Label With Custom Views")
+                            .fontWeight(.heavy)
+                        Text("It's also possible to make labels using views to compose the label's icon")
+                            .fontWeight(.light)
+                    }
+                    .padding()
+                    
                     /// It's also possible to make labels using views to compose the label's icon
                     /// programmatically, rather than using a pre-made image. In this example, the
                     /// icon portion of the label uses a filled ``Circle`` overlaid
@@ -170,17 +198,24 @@ struct LabelsView: View {
                             .foregroundColor(.secondary)
                     } icon: {
                         Circle()
-                            .fill(Color.gray)
+                            .fill(Color.accentColor)
                             .frame(width: 44, height: 44, alignment: .center)
-                            .overlay(Text("A+"))
+                            .overlay(Text("A+").foregroundColor(.white))
                     }
+                    .padding()
                 }
-                .padding()
+              
             }
             
             // MARK: - TRUNCATION AND MULTILINE
             Group {
-                HeaderView(title: "truncations and multiline")
+                Group {
+                    Text("truncations and multiline")
+                        .fontWeight(.heavy)
+                    Text("Similar configuration as there were in UIKit can be applied in SwiftUI to manage truncation and multiline text in a label")
+                        .fontWeight(.light)
+                }
+                .padding()
                 
                 Label(
                     title: { Text("Very long text truncated")
@@ -188,7 +223,7 @@ struct LabelsView: View {
                     },
                     icon: {}
                 )
-                .frame(width: 150, height: 100, alignment: /*@START_MENU_TOKEN@*/.center/*@END_MENU_TOKEN@*/)
+                .frame(width: 150, height: 100, alignment: .center)
                 .lineLimit(1)
                 .allowsTightening(false)
                 .truncationMode(.middle)
@@ -204,7 +239,7 @@ struct LabelsView: View {
                 .allowsTightening(true)
                 .truncationMode(.middle)
             }
-            .padding(5)
+       
         }
     }
 }

--- a/SwiftUICatalog/Views/Sections/Controls/MenuesView.swift
+++ b/SwiftUICatalog/Views/Sections/Controls/MenuesView.swift
@@ -38,10 +38,19 @@ struct MenusComponentView: View {
     
     var body: some View {
         ScrollView{
+            
+            HeaderView(title: "Menues in SwiftUI")
+
             Group {
-                HeaderView(title: "Menus")
-                Text("A control for presenting a menu of actions.")
-                    .fontWeight(.regular)
+                
+                // Contextual information: a short intro to the elements we are showcasing
+                Group {
+                    Text( "Menus")
+                        .fontWeight(.heavy)
+                    Text("A control for presenting a menu of actions.")
+                        .fontWeight(.light)
+                }
+                
                 HStack {
                     Text("Menu + Sub-Menu").fontWeight(.light)
                     Spacer()

--- a/SwiftUICatalog/Views/Sections/Controls/ProgressViews.swift
+++ b/SwiftUICatalog/Views/Sections/Controls/ProgressViews.swift
@@ -35,7 +35,17 @@ import SwiftUI
 
 struct ProgressViews: View {
     var body: some View {
-        Text("ProgressView in SwiftUI")
+        
+        HeaderView(title: "ProgressView in SwiftUI")
+        
+        // Contextual information: a short intro to the elements we are showcasing
+        Group {
+            Text("title")
+                .fontWeight(.heavy)
+            Text("description of what we show case")
+                .fontWeight(.light)
+        }
+        .padding()
     }
 }
 

--- a/SwiftUICatalog/Views/Sections/Controls/SlidersView.swift
+++ b/SwiftUICatalog/Views/Sections/Controls/SlidersView.swift
@@ -47,8 +47,17 @@ struct SlidersView: View {
     
     var body: some View {
 
-        List {
-            HeaderView(title: "Slider with continued values")
+        ScrollView {
+            HeaderView(title: "Sliders in SwiftUI")
+
+            Group {
+                Text( "Slider with continued values")
+                    .fontWeight(.heavy)
+                Text("A slider can be configured with a range of values through which continued numbers can be selected. In this example there is a selection of grams for some tasty receipt.")
+                    .fontWeight(.light)
+            }
+            .padding()
+            
             VStack {
                 Slider(
                     value: $grams1,
@@ -64,7 +73,14 @@ struct SlidersView: View {
             .padding(10)
             // end of v stack
             
-            HeaderView(title: "Slider with steps")
+            Group {
+                Text("Slider with steps")
+                    .fontWeight(.heavy)
+                Text("A slider can also be configured with a step value, that will make the choose values jump depending on the size of the step, for example here from 20 to 20 more.")
+                    .fontWeight(.light)
+            }
+            .padding()
+            
             VStack {
                 Slider(
                     value: $grams2,
@@ -81,7 +97,14 @@ struct SlidersView: View {
             .padding(10)
             // end of v stack
             
-            HeaderView(title: "Slider with VoiceOver Label & min / max values")
+            Group {
+                Text( "Slider with VoiceOver Label & min / max values")
+                    .fontWeight(.heavy)
+                Text("A slider can also be contained between a minimum and a maximum value. Here a label is also added to the slider, whose text will be spoken in VoiceOver to improve accessibility")
+                    .fontWeight(.light)
+            }
+            .padding()
+            
             VStack {
                 Slider(value: $grams3,
                        in: 0...1000,

--- a/SwiftUICatalog/Views/Sections/Controls/TextsView.swift
+++ b/SwiftUICatalog/Views/Sections/Controls/TextsView.swift
@@ -41,27 +41,68 @@ struct TextsComponentsView: View {
     
     var body: some View {
         ScrollView {
+            
+            HeaderView(title: "TextViews in SwiftUI")
+
+            
             // MARK: - FONTS
             Group {
-                HeaderView(title: "Available fonts")
+                
+                // Contextual information: a short intro to the elements we are showcasing
+                Group {
+                    Text("Available fonts")
+                        .fontWeight(.heavy)
+                    Text("To apply a specific font to an individual Text View you can use the font modifier. There are already different type of fonts pre-defined")
+                        .fontWeight(.light)
+                }
+                .padding()
 
                 Spacer()
                 Group {
-                    Text("Title")
-                        .font(.title)
-                    Text("Title 2")
-                        .font(.title2)
-                    Text("Title 3")
-                        .font(.title3)
+                    Group {
+                        Text("Headline")
+                            .font(.headline)
+                        Text("Sub headline")
+                            .font(.subheadline)
+                        Text("Large title")
+                            .font(.largeTitle)
+                        Text("Title")
+                            .font(.title)
+                        Text("Title 2")
+                            .font(.title2)
+                    }
+                    Group {
+                        Text("Title 3")
+                            .font(.title3)
+                        Text("Body")
+                            .font(.body)
+                        Text("Callout")
+                            .font(.callout)
+                        Text("Caption")
+                            .font(.caption)
+                        Text("Caption 2")
+                            .font(.caption2)
+                        Text("Footnote")
+                            .font(.footnote)
+                    }
+
                 }
                 .padding(5)
                 Spacer()
                 Spacer()
 
             }
+            
             // MARK: - FONT WEIGHTS
             Group {
-                HeaderView(title: "Available font weights")
+                
+                Group {
+                    Text("Available font weights")
+                        .fontWeight(.heavy)
+                    Text("Fonts can also be assigned a weight, which will change the appereance of the font")
+                        .fontWeight(.light)
+                }
+                .padding()
 
                 Group {
                     Text("Weight Black")
@@ -88,9 +129,12 @@ struct TextsComponentsView: View {
                 Spacer()
 
             }
+            
             // MARK: - FONTS ITALIC, BOLD
             Group {
-                HeaderView(title: "Text, italic, bold")
+                Text( "Text, italic, bold")
+                    .fontWeight(.heavy)
+                    .padding()
 
                 Group {
                     Text("Italic")
@@ -112,12 +156,13 @@ struct TextsComponentsView: View {
                                 y: 3.0)
 
                 }
-                .padding(5)
-                Spacer()
+              
             }
             // MARK: - TRUNCATION AND MULTILINE
             Group {
-                HeaderView(title: "Text, truncations and multiline")
+                Text( "Text, truncations and multiline")
+                    .fontWeight(.heavy)
+                    .padding()
 
                 Text("Very long text truncated")
                     .frame(width: 150)
@@ -128,10 +173,13 @@ struct TextsComponentsView: View {
                 Text("Multiline text arranged in how many lines as it is needed")
                     .multilineTextAlignment(.center)
             }
-            .padding(5)
+            
+          
             // MARK: - TRANSLATIONS
             Group {
-                HeaderView(title: "Text and translations")
+                Text( "Text and translations")
+                    .fontWeight(.heavy)
+                    .padding()
 
                 Group {
                     // automatically looks in the bundle localised strings file
@@ -139,13 +187,20 @@ struct TextsComponentsView: View {
                     // skip trying to localise the string
                     Text(verbatim: "nottranslated")
                 }
-                .padding(5)
-                Spacer()
+              
             }
+            
             // MARK: - TEXT AND DATES
             Group {
                 Group {
-                    HeaderView(title: "Text and dates")
+                    Group {
+                        Text("Text and dates")
+                            .fontWeight(.heavy)
+                        Text("There are ways to present a date inside a text element allowing it to be formatted with different styles and timers.")
+                            .fontWeight(.light)
+                    }
+                    .padding()
+                    
                     HStack {
                         Text("Text with date:")
                         Spacer()
@@ -178,7 +233,14 @@ struct TextsComponentsView: View {
             // MARK: - text controls
             Group {
                 Group {
-                    HeaderView(title: "Text controls")
+                    
+                    Group {
+                        Text("Text controls")
+                            .fontWeight(.heavy)
+                        Text("SwiftUI comes with 2 pre-defined text controls: text fields and secure text field to utilise with for example password entries.")
+                            .fontWeight(.light)
+                    }
+                    .padding()
 
                     HStack {
                         Text("Text field:")

--- a/SwiftUICatalog/Views/Sections/Controls/TogglesView.swift
+++ b/SwiftUICatalog/Views/Sections/Controls/TogglesView.swift
@@ -37,8 +37,20 @@ struct TogglesView: View {
     @State var isCustomToggleOn: Bool = true
 
     var body: some View {
-        VStack(spacing: 20) {
-            HeaderView(title: "Toggles")
+        VStack() {
+
+            HeaderView(title: "Toggles in SwiftUI")
+
+            
+            // Contextual information: a short intro to the elements we are showcasing
+            Group {
+                Text("Toggles")
+                    .fontWeight(.heavy)
+                Text("You create a toggle by providing an isOn binding and a label. Bind isOn to a Boolean property that determines whether the toggle is on or off")
+                    .fontWeight(.light)
+            }
+            .padding()
+            
             Toggle(
                 isOn: $isBasicToggleOn,
                 label: {
@@ -62,9 +74,10 @@ struct TogglesView: View {
                 }
             )
             .toggleStyle(CustomToggleStyle())
-
+            Spacer()
         }
         .padding()
+      
     }
 }
 

--- a/SwiftUICatalog/Views/Sections/Drawing and Animations/AnimationsView.swift
+++ b/SwiftUICatalog/Views/Sections/Drawing and Animations/AnimationsView.swift
@@ -55,16 +55,30 @@ struct AnimationsView: View {
         
         NavigationView {
             
+            
             List {
+                
+                HeaderView(title: "Animations in SwiftUI")
+
                 Link(destination:                         RobbieWithPulseView(),
                      label: "Pulse animation")
                 Link(destination: PropertiesAnimationsView(),
                      label: "Properties animations")
                 Link(destination: TransitionsAnimationsView(),
                      label: "Transitions animations")
-                Link(destination: MotionAnimationView(),
+                Link(destination: VStack {
+                    Group {
+                        Text("Circles in motion animation")
+                            .fontWeight(.heavy)
+                        Text("A custom complex animation using geometryr reader to create shapes and make them move and scale around the screen")
+                            .fontWeight(.light)
+                        MotionAnimationView()
+                    }
+                    .padding()
+                } ,
                      label: "Moving circles animations")
             }
+            Spacer()
 
         }
         .navigationTitle("Animations")
@@ -111,15 +125,22 @@ struct PropertiesAnimationsView: View {
 
     var body: some View {
         
-        VStack(alignment: .center) {
-            List {
-                Text( "*Touch on the images")
-                    .font(.footnote)
+            ScrollView {
                 
+                HeaderView(title: "Animating an image in SwiftUI")
                 // MARK: - animating local properties
                 
                 Group {
-                    HeaderView(title: "Animating a toggle on a boolean")
+                    
+                    Group {
+                        Text( "Animating a toggle on a boolean")
+                            .fontWeight(.heavy)
+                        Text("Using a boolean you can play around with different types of animations")
+                            .fontWeight(.light)
+
+                    }
+                    .padding()
+                    
                     Button(action: {
                         withAnimation(.easeInOut(duration: 3)) {
                             self.animate3.toggle()
@@ -144,7 +165,14 @@ struct PropertiesAnimationsView: View {
                 
                 // MARK: - rotation animated
                 Group {
-                    HeaderView(title: "Rotation animated easeIn Out")
+                    Group {
+                        Text( "Rotation animated")
+                            .fontWeight(.heavy)
+                        Text("Using a rotation effect and changing the degrees of the angle you can achieve a different animation")
+                            .fontWeight(.light)
+                    }
+                    .padding()
+                    
                     Button(action: {
                         self.animate1.toggle()
                     }) {
@@ -166,7 +194,15 @@ struct PropertiesAnimationsView: View {
                 
                 // MARK: - Spring rotation
                 Group {
-                    HeaderView(title: "Rotation animation with Spring")
+                    Group {
+                        Text("Rotation animation with Spring")
+                            .fontWeight(.heavy)
+                        Text("A different type of effect is achieved by using a spring animation")
+                            .fontWeight(.light)
+
+                    }
+                    .padding()
+                    
                     Button(action: {
                         self.animate2.toggle()
                     }) {
@@ -189,7 +225,13 @@ struct PropertiesAnimationsView: View {
                 
                 // MARK: - ripple
                 Group {
-                    HeaderView(title: "Ripple animation")
+                    Group {
+                        Text("Ripple animation")
+                            .fontWeight(.heavy)
+                        Text("Here's an example of how to use your custom defined animation to simulate a ripple effect on an image")
+                            .fontWeight(.light)
+                    }
+                    .padding()
                     Button(action: {
                         self.animate4.toggle()
                     }) {
@@ -212,8 +254,6 @@ struct PropertiesAnimationsView: View {
 
             }
             // end of list
-        }
-        // end of v stack
 
     }
     

--- a/SwiftUICatalog/Views/Sections/Drawing and Animations/CanvasView.swift
+++ b/SwiftUICatalog/Views/Sections/Drawing and Animations/CanvasView.swift
@@ -36,7 +36,16 @@ import SwiftUI
 
 struct CanvasView: View {
     var body: some View {
-        Text("Canvas in SwiftUI")
+        HeaderView( title: "Canvas in SwiftUI")
+        
+        // Contextual information: a short intro to the elements we are showcasing
+        Group {
+            Text("title")
+                .fontWeight(.heavy)
+            Text("description of what we show case")
+                .fontWeight(.light)
+        }
+        .padding()
     }
 }
 

--- a/SwiftUICatalog/Views/Sections/Drawing and Animations/GeometriesView.swift
+++ b/SwiftUICatalog/Views/Sections/Drawing and Animations/GeometriesView.swift
@@ -43,7 +43,16 @@ import SwiftUI
 
 struct GeometriesView: View {
     var body: some View {
-        Text("Geometry, readers, proxy, effects, anchors, edges, angles, and projections in SwiftUI")
+        HeaderView( title: "Geometry, readers, proxy, effects, anchors, edges, angles, and projections in SwiftUI")
+        
+        // Contextual information: a short intro to the elements we are showcasing
+        Group {
+            Text("title")
+                .fontWeight(.heavy)
+            Text("description of what we show case")
+                .fontWeight(.light)
+        }
+        .padding()
     }
 }
 

--- a/SwiftUICatalog/Views/Sections/Drawing and Animations/GraphicContextsView.swift
+++ b/SwiftUICatalog/Views/Sections/Drawing and Animations/GraphicContextsView.swift
@@ -36,7 +36,16 @@ import SwiftUI
 
 struct GraphicContextsView: View {
     var body: some View {
-        Text("Graphic contexts in SwiftUI")
+        HeaderView( title: "Graphic contexts in SwiftUI")
+        
+        // Contextual information: a short intro to the elements we are showcasing
+        Group {
+            Text("title")
+                .fontWeight(.heavy)
+            Text("description of what we show case")
+                .fontWeight(.light)
+        }
+        .padding()
     }
 }
 

--- a/SwiftUICatalog/Views/Sections/Drawing and Animations/ShapesView.swift
+++ b/SwiftUICatalog/Views/Sections/Drawing and Animations/ShapesView.swift
@@ -54,65 +54,64 @@ struct ShapesView: View {
         
         ScrollView {
             
-            // MARK: - rectangle
+            HeaderView(title: "Shapes in SwiftUI")
+            
+            // contextual information
+            Group {
+                Text("Rectangles, circles, ellipse and capsules")
+                    .fontWeight(.heavy)
+                
+                Text("SwiftUI brings some pre-defined shapes like rectabgles and circles. But there is also the chance to define your own shapes by creating a path")
+                    .fontWeight(.light)
+            }
+            .padding()
+            
             
             Group {
-                HeaderView(title: "Rectangle")
+                // MARK: - rectangle
                 Rectangle()
                     .fill(Color.yellow)
                     .frame(width: 100, height: 100)
-            }
-            
-            // MARK: - Circle
-            
-            Group {
-                HeaderView(title: "Circle")
+                // MARK: - Circle
                 Circle()
                     .fill(Color.yellow)
                     .frame(width: 100, height: 100)
-            }
-            
-            // MARK: - Ellipse
-            
-            Group {
-                HeaderView(title: "Ellipse")
-                Ellipse()
-                    .fill(Color.yellow)
-                    .frame(width: 100, height: 200)
-            }
-            
-            // MARK: - capsule
-            
-            Group {
-                HeaderView(title: "Capsule")
-                Capsule()
-                    .fill(Color.yellow)
-                    .frame(width: 100, height: 150)
+                // MARK: - Ellipse
+                    Ellipse()
+                        .fill(Color.yellow)
+                        .frame(width: 100, height: 200)
+                // MARK: - capsule
+                    Capsule()
+                        .fill(Color.yellow)
+                        .frame(width: 100, height: 150)
 
+                // MARK: - rounded rectangle
+                   RoundedRectangle(cornerSize: CGSize(width: 10, height: 10))
+                     .fill(Color.yellow)
+                     .frame(width: 100, height: 100)
+                
             }
-            
-            // MARK: - rounded rectangle
-            
-            Group {
-                HeaderView(title: "Rounded Rectangle")
-                RoundedRectangle(cornerSize: CGSize(width: 10, height: 10))
-                    .fill(Color.yellow)
-                    .frame(width: 100, height: 100)
-            }
+            .padding()
+           
+        
             
             // MARK: - custom
             
             Group {
-                HeaderView(title: "Custom shape")
+                
+                Text("Custom shape")
+                    .fontWeight(.heavy)
                 CustomShape()
                     .fill(Color.yellow)
                     .frame(width: 100, height: 100)
             }
+            .padding()
 
             // MARK: - insetable shape
             
             Group {
-                HeaderView(title: "Insettable shape")
+                Text("Insettable shape")
+                    .fontWeight(.heavy)
                 Rectangle()
                     .strokeBorder(style: StrokeStyle(lineWidth: 5,
                                                      lineCap: CGLineCap.round,
@@ -122,6 +121,7 @@ struct ShapesView: View {
                                                      dashPhase: 4))
                     .frame(width: 100, height: 100)
             }
+            .padding()
 
 
         }

--- a/SwiftUICatalog/Views/Sections/Hierarchical Views/DisclosureGroupsView.swift
+++ b/SwiftUICatalog/Views/Sections/Hierarchical Views/DisclosureGroupsView.swift
@@ -36,7 +36,16 @@ import SwiftUI
 
 struct DisclosureGroupsView: View {
     var body: some View {
-        Text("Disclosure groups in SwiftUI")
+        HeaderView( title: "Disclosure groups in SwiftUI")
+        
+        // Contextual information: a short intro to the elements we are showcasing
+        Group {
+            Text("title")
+                .fontWeight(.heavy)
+            Text("description of what we show case")
+                .fontWeight(.light)
+        }
+        .padding()
     }
 }
 

--- a/SwiftUICatalog/Views/Sections/Hierarchical Views/NavigationView.swift
+++ b/SwiftUICatalog/Views/Sections/Hierarchical Views/NavigationView.swift
@@ -35,7 +35,16 @@ import SwiftUI
 ///
 struct NavigationBarsComponentView: View {
     var body: some View {
-        Text("Navigation Views in SwiftUI")
+        HeaderView( title: "Navigation Views in SwiftUI")
+        
+        // Contextual information: a short intro to the elements we are showcasing
+        Group {
+            Text("title")
+                .fontWeight(.heavy)
+            Text("description of what we show case")
+                .fontWeight(.light)
+        }
+        .padding()
     }
 }
 

--- a/SwiftUICatalog/Views/Sections/Hierarchical Views/OutlinesGroupsView.swift
+++ b/SwiftUICatalog/Views/Sections/Hierarchical Views/OutlinesGroupsView.swift
@@ -35,7 +35,16 @@ import SwiftUI
 
 struct OutlinesGroupsView: View {
     var body: some View {
-        Text("Outline groups in SwiftUI")
+        HeaderView( title: "Outline groups in SwiftUI")
+        
+        // Contextual information: a short intro to the elements we are showcasing
+        Group {
+            Text("title")
+                .fontWeight(.heavy)
+            Text("description of what we show case")
+                .fontWeight(.light)
+        }
+        .padding()
     }
 }
 

--- a/SwiftUICatalog/Views/Sections/Hierarchical Views/TabsView.swift
+++ b/SwiftUICatalog/Views/Sections/Hierarchical Views/TabsView.swift
@@ -36,7 +36,16 @@ import SwiftUI
 
 struct TabsView: View {
     var body: some View {
-        Text("Tab views in Swift UI")
+        HeaderView( title: "Tab views in Swift UI")
+        
+        // Contextual information: a short intro to the elements we are showcasing
+        Group {
+            Text("title")
+                .fontWeight(.heavy)
+            Text("description of what we show case")
+                .fontWeight(.light)
+        }
+        .padding()
     }
 }
 

--- a/SwiftUICatalog/Views/Sections/Styles/StylesView.swift
+++ b/SwiftUICatalog/Views/Sections/Styles/StylesView.swift
@@ -35,7 +35,16 @@ import SwiftUI
 ///
 struct StylesView: View {
     var body: some View {
-        Text("Styling views in SwiftUI")
+        HeaderView( title: "Styling views in SwiftUI")
+        
+        // Contextual information: a short intro to the elements we are showcasing
+        Group {
+            Text("title")
+                .fontWeight(.heavy)
+            Text("description of what we show case")
+                .fontWeight(.light)
+        }
+        .padding()
     }
 }
 

--- a/SwiftUICatalog/Views/Sections/View Layouts/ContainersView.swift
+++ b/SwiftUICatalog/Views/Sections/View Layouts/ContainersView.swift
@@ -38,7 +38,16 @@ import SwiftUI
 
 struct ContainersView: View {
     var body: some View {
-        Text("Form, group, GroupBox & Control Group in SwiftUI")
+        HeaderView(title:"Form, group, GroupBox & Control Group in SwiftUI")
+        
+        // Contextual information: a short intro to the elements we are showcasing
+        Group {
+            Text("title")
+                .fontWeight(.heavy)
+            Text("description of what we show case")
+                .fontWeight(.light)
+        }
+        .padding()
     }
 }
 

--- a/SwiftUICatalog/Views/Sections/View Layouts/GridsView.swift
+++ b/SwiftUICatalog/Views/Sections/View Layouts/GridsView.swift
@@ -38,7 +38,16 @@ import SwiftUI
 
 struct GridsView: View {
     var body: some View {
-        Text("Lazy / H & V Grids in SwiftUI")
+        HeaderView( title: "Lazy / H & V Grids in SwiftUI")
+        
+        // Contextual information: a short intro to the elements we are showcasing
+        Group {
+            Text("title")
+                .fontWeight(.heavy)
+            Text("description of what we show case")
+                .fontWeight(.light)
+        }
+        .padding()
     }
 }
 

--- a/SwiftUICatalog/Views/Sections/View Layouts/ListsView.swift
+++ b/SwiftUICatalog/Views/Sections/View Layouts/ListsView.swift
@@ -42,7 +42,23 @@ struct ListsComponentView: View {
     @State private var singleSelection : UUID?
     
     var body: some View {
+        
         List(selection: $singleSelection){
+             
+            HStack {
+                Spacer()
+                HeaderView(title: "Lists in SwiftUI")
+                Spacer()
+            }
+            // contextual information
+            Group {
+                Text("An example of a list with sections")
+                    .fontWeight(.heavy)
+                Text("Here we show an example of how a list can be configured based of the data coming from a double entry structure (countries and dog's breeds)")
+                    .fontWeight(.light)
+            }
+            .padding()
+            
             ForEach(countries) { c in
                 Section(header: Text("\(c.name)")
                             .font(.title)

--- a/SwiftUICatalog/Views/Sections/View Layouts/ScrollViewsView.swift
+++ b/SwiftUICatalog/Views/Sections/View Layouts/ScrollViewsView.swift
@@ -37,7 +37,16 @@ import SwiftUI
 
 struct ScrollViewsView: View {
     var body: some View {
-        Text("Scroll views in SwiftUI")
+        HeaderView( title: "Scroll views in SwiftUI")
+        
+        // Contextual information: a short intro to the elements we are showcasing
+        Group {
+            Text("title")
+                .fontWeight(.heavy)
+            Text("description of what we show case")
+                .fontWeight(.light)
+        }
+        .padding()
     }
 }
 

--- a/SwiftUICatalog/Views/Sections/View Layouts/StacksView.swift
+++ b/SwiftUICatalog/Views/Sections/View Layouts/StacksView.swift
@@ -40,7 +40,16 @@ import SwiftUI
 
 struct StacksView: View {
     var body: some View {
-        Text("Lazy / H - V & Z Stack views in SwiftUI")
+        HeaderView( title: "Lazy / H - V & Z Stack views in SwiftUI")
+        
+        // Contextual information: a short intro to the elements we are showcasing
+        Group {
+            Text("title")
+                .fontWeight(.heavy)
+            Text("description of what we show case")
+                .fontWeight(.light)
+        }
+        .padding()
     }
 }
 

--- a/SwiftUICatalog/Views/Sections/View Layouts/TablesView.swift
+++ b/SwiftUICatalog/Views/Sections/View Layouts/TablesView.swift
@@ -35,7 +35,16 @@ import SwiftUI
 
 struct TablesView: View {
     var body: some View {
-        Text("Table views in SwiftUI")
+        HeaderView( title: "Table views in SwiftUI")
+        
+        // Contextual information: a short intro to the elements we are showcasing
+        Group {
+            Text("title")
+                .fontWeight(.heavy)
+            Text("description of what we show case")
+                .fontWeight(.light)
+        }
+        .padding()
     }
 }
 

--- a/SwiftUICatalog/Views/Sections/View Modifiers/CustomModifiersView.swift
+++ b/SwiftUICatalog/Views/Sections/View Modifiers/CustomModifiersView.swift
@@ -36,7 +36,16 @@ import SwiftUI
 
 struct CustomModifiersView: View {
     var body: some View {
-        Text("Some custom modifiers in SwiftUI")
+        HeaderView(title : "Some custom modifiers in SwiftUI")
+        
+        // Contextual information: a short intro to the elements we are showcasing
+        Group {
+            Text("title")
+                .fontWeight(.heavy)
+            Text("description of what we show case")
+                .fontWeight(.light)
+        }
+        .padding()
     }
 }
 

--- a/SwiftUICatalog/Views/Sections/View Modifiers/LayoutModifiersView.swift
+++ b/SwiftUICatalog/Views/Sections/View Modifiers/LayoutModifiersView.swift
@@ -36,7 +36,16 @@ import SwiftUI
 
 struct LayoutModifiersView: View {
     var body: some View {
-        Text("Examples of layout modifiers")
+        HeaderView( title: "Examples of layout modifiers")
+        
+        // Contextual information: a short intro to the elements we are showcasing
+        Group {
+            Text("title")
+                .fontWeight(.heavy)
+            Text("description of what we show case")
+                .fontWeight(.light)
+        }
+        .padding()
     }
 }
 

--- a/SwiftUICatalog/Views/Sections/View Modifiers/TextModifiersView.swift
+++ b/SwiftUICatalog/Views/Sections/View Modifiers/TextModifiersView.swift
@@ -36,7 +36,16 @@ import SwiftUI
 
 struct TextModifiersView: View {
     var body: some View {
-        Text("Examples of all possible text modifiers to be used")
+        HeaderView( title: "Examples of all possible text modifiers to be used")
+        
+        // Contextual information: a short intro to the elements we are showcasing
+        Group {
+            Text("title")
+                .fontWeight(.heavy)
+            Text("description of what we show case")
+                .fontWeight(.light)
+        }
+        .padding()
     }
 }
 


### PR DESCRIPTION
Based on the Stepper documentation, I created a new design to add more description about what we are showcasing.
The contextual information group contains 2 text, in heavy and light fonts and are intended to provide the viewers of the catalog a quick overview of the components showcased.

